### PR TITLE
Add Fructus.xyz and Fructus.co to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -756,7 +756,9 @@
     "metamash.io",
     "cactus.black",
     "amatus.capital",
-    "nfinite.app"
+    "nfinite.app",
+    "fructus.xyz",
+    "fructus.co"
   ],
   "blacklist": [
     "walletconnectrestore.io",


### PR DESCRIPTION
Related to issues #5435 : Add fructus.xyz and fructus.co to allowlist
https://github.com/MetaMask/eth-phishing-detect/issues/5435